### PR TITLE
fix spice/Makefile dependency problem

### DIFF
--- a/spice/Makefile
+++ b/spice/Makefile
@@ -20,7 +20,7 @@ SRC =	passpice.c
 
 all: cspice $(SO_Name)
 
-$(SO_Name): $(OBJS)
+$(SO_Name): cspice $(OBJS)
 	$(CC) $(CFLAGS) $(LIBFLAGS) -o $@ $(SRC) $(LIBS)
 
 cspice:

--- a/spice/Makefile.win32
+++ b/spice/Makefile.win32
@@ -12,7 +12,7 @@ SRC =	passpice.c
 
 all: cspice $(SO_Name)
 
-$(SO_Name): $(OBJS)
+$(SO_Name): cspice $(OBJS)
 	$(CC) $(CFLAGS) $(LIBFLAGS) -o $@ $(SRC) $(LIBS)
 
 cspice:

--- a/spice/Makefile.win64
+++ b/spice/Makefile.win64
@@ -12,7 +12,7 @@ SRC =	passpice.c
 
 all: cspice $(SO_Name)
 
-$(SO_Name): $(OBJS)
+$(SO_Name): cspice $(OBJS)
 	$(CC) $(CFLAGS) $(LIBFLAGS) -o $@ $(SRC) $(LIBS)
 
 cspice:


### PR DESCRIPTION
cspice should be a dependency of libpasspice.so.1, otherwise it may be built before cspice and fail

I am experiencing this problem when building on Arch Linux. The libpasspice.so.1 is being built before entering the cspice directory and fails. Tested on Arch Linux, but I don't have a Windows to test.