### PR TITLE
minimal fixes to allow modern compilers to build libpasastro

### DIFF
--- a/plan404/cmoon.c
+++ b/plan404/cmoon.c
@@ -128,6 +128,8 @@
 
 #include "plantbl.h"
 
+extern int epsiln(double J);
+
 /* The following coefficients were calculated by a simultaneous least
  * squares fit between the analytical theory and DE404 on the finite
  * interval from -3000 to +3000.

--- a/wcs/cdcwcs.c
+++ b/wcs/cdcwcs.c
@@ -127,7 +127,7 @@ int wcsnum;
 }  
 
 int cdcwcs_sky2xy ( p,  wcsnum )
-struct cdcCoord *p;
+struct cdcCoord *p; int wcsnum;
 {
 double ra, dec, x, y;
 int offscale;  
@@ -149,7 +149,7 @@ return(offscale);
 }
 
 int cdcwcs_xy2sky ( p,  wcsnum )
-struct cdcCoord *p;
+struct cdcCoord *p; int wcsnum;
 {
 double ra, dec, x, y;
 if (wcs[wcsnum] != NULL ) {


### PR DESCRIPTION
Commits:
fixes implicit declaration of epsln(J) in cmoon.c
fixes implicit int in cdcwcs_sky2xy and cdcwcs_xy2sky