### PR TITLE
Fix build issues on Arch Linux with GCC 14.2.1.

### DIFF
--- a/plan404/cmoon.c
+++ b/plan404/cmoon.c
@@ -560,6 +560,7 @@ double Rearth =  4.263521245682888527856e-05;
 extern double STR, DTR, J2000;
 int moon1(), moon2(), moon3(), moon4(), chewm(), sscc();
 
+int epsiln();
 
 #if AASUB
 

--- a/wcs/cdcwcs.c
+++ b/wcs/cdcwcs.c
@@ -128,6 +128,7 @@ int wcsnum;
 
 int cdcwcs_sky2xy ( p,  wcsnum )
 struct cdcCoord *p;
+int wcsnum;
 {
 double ra, dec, x, y;
 int offscale;  
@@ -150,6 +151,7 @@ return(offscale);
 
 int cdcwcs_xy2sky ( p,  wcsnum )
 struct cdcCoord *p;
+int wcsnum;
 {
 double ra, dec, x, y;
 if (wcs[wcsnum] != NULL ) {


### PR DESCRIPTION
The newest gcc releases are again less tolerant, this patch fixes some minor issues.