### PR TITLE
Fix build with GCC15

### DIFF
--- a/plan404/cmoon.c
+++ b/plan404/cmoon.c
@@ -127,6 +127,7 @@
  */
 
 #include "plantbl.h"
+#include <math.h>
 
 extern int epsiln(double J);
 
@@ -551,7 +552,7 @@ double Rem;
 
 /* Beware of atan2()!
  */
-double floor(), sin(), cos(), asin(), mods3600();
+double mods3600(double);
 
 /* equatorial radius of the earth, in au
  */
@@ -560,7 +561,7 @@ double Rearth =  4.263521245682888527856e-05;
 #define Kearth 6378.137
 
 extern double STR, DTR, J2000;
-int moon1(), moon2(), moon3(), moon4(), chewm(), sscc();
+int moon1(), moon2(), moon3(), moon4(int), chewm(short*,int,int,int,double*), sscc(int,double,int);
 
 
 #if AASUB
@@ -845,7 +846,6 @@ double mods3600(x)
 double x;
 {
 double lx;
-double floor();
 
 lx = x;
 lx = lx - 1296000.0 * floor( lx/1296000.0 );

--- a/plan404/epsiln.c
+++ b/plan404/epsiln.c
@@ -21,6 +21,7 @@
  * 
  */
  #include "plantbl.h"
+ #include <math.h>
 
 /* The results of the program are returned in these
  * global variables:
@@ -30,7 +31,6 @@ double eps = 0.0; /* The computed obliquity in radians */
 double coseps = 0.0; /* Cosine of the obliquity */
 double sineps = 0.0; /* Sine of the obliquity */
 extern double eps, coseps, sineps, STR;
-double sin(), cos(), fabs();
 
 int epsiln(J)
 double J; /* Julian date input */

--- a/plan404/gplan.c
+++ b/plan404/gplan.c
@@ -1,4 +1,5 @@
 #include "plantbl.h"
+#include <math.h>
 #define TIMESCALE 3652500.0
 #define mods3600(x) ((x) - 1.296e6 * floor ((x)/1.296e6))
 
@@ -43,8 +44,7 @@ static double phases[] =
 static double ss[9][24];
 static double cc[9][24];
 
-double cos (), sin (), floor (), fabs ();
-static int sscc ();
+static int sscc (int,double,int);
 
 int 
 gplan (J, plan, pobj)

--- a/plan404/nutate.c
+++ b/plan404/nutate.c
@@ -21,6 +21,7 @@
  *                 tested against JPL DE403 ephemeris file.
  */
 #include "plantbl.h"
+#include <math.h>
 
 /* The answers are posted here by nutlo():
  */
@@ -173,9 +174,8 @@ short nt[105*9] = {
 double ss[5][8];
 double cc[5][8];
 extern double ss[5][8], cc[5][8];
-int sscc(), epsiln(), showcor();
+int sscc(int,double,int), epsiln(double), showcor();
 
-double sin(), cos(), floor();
 #define mod3600(x) ((x) - 1296000. * floor ((x)/1296000.))
 
 int nutlo(J)
@@ -317,7 +317,6 @@ double p[];
 double ce, se, cl, sl, sino, f;
 double dp[3], p1[3];
 int i;
-double sin(), cos();
 
 nutlo(J); /* be sure we calculated nutl and nuto */
 epsiln(J); /* and also the obliquity of date */
@@ -369,7 +368,6 @@ int n;
 {
 double cu, su, cv, sv, s;
 int i;
-double sin(), cos();
 
 su = sin(arg);
 cu = cos(arg);

--- a/plan404/plan404.c
+++ b/plan404/plan404.c
@@ -34,6 +34,7 @@
 */
 
 #include <stdio.h>
+#include <math.h>
 #include "plantbl.h"
 #include "plan404.h"
 
@@ -53,11 +54,12 @@ struct plantbl *planets[] =
   &plu404
 };
 
+typedef struct plantbl Plantbl;
+
 double sineps2k = 3.97777155754e-1; // ecliptic J2000
 double coseps2k = 9.17482062146e-1;
 
-double cos (), sin ();
-int gplan (), gmoon ();
+int gplan (double,Plantbl*,double*), gmoon (double,double*,double*);
 
 int Plan404 ( pla ) 
  struct PlanetData *pla;

--- a/plan404/precess.c
+++ b/plan404/precess.c
@@ -3,6 +3,7 @@
  *
  * Program by Steve Moshier.  */
 #include "plantbl.h"
+#include <math.h>
 
 #define WILLIAMS 1
 /* James G. Williams, "Contributions to the Earth's obliquity rate,
@@ -62,13 +63,12 @@
  */
 
 #define DOUBLE double
-double cos(), sin();
 #define COS cos
 #define SIN sin
 extern DOUBLE J2000; /* = 2451545.0, 2000 January 1.5 */
 extern DOUBLE STR; /* = 4.8481368110953599359e-6 radians per arc second */
 extern DOUBLE coseps, sineps; /* see epsiln.c */
-extern int epsiln();
+extern int epsiln(double);
 
 /* In WILLIAMS and SIMON, Laskar's terms of order higher than t^4
    have been retained, because Simon et al mention that the solution

--- a/wcs/Makefile
+++ b/wcs/Makefile
@@ -1,5 +1,5 @@
 # 
-CFLAGS= -w -fPIC $(arch_flags)
+CFLAGS= -w -fPIC $(arch_flags) -std=c99 -D_XOPEN_SOURCE=500
 OSTYPE = $(shell uname)
 ifneq ($(findstring BSD,$(OSTYPE)),)
 CC            = cc

--- a/wcs/dateutil.c
+++ b/wcs/dateutil.c
@@ -305,6 +305,8 @@
  *	Return Mod of floating point number
  */
 
+#define _GNU_SOURCE
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/wcs/fileutil.c
+++ b/wcs/fileutil.c
@@ -71,6 +71,7 @@
 #include <sys/file.h>
 #include <errno.h>
 #include <string.h>
+#include <strings.h>
 #include "fitsfile.h"
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/wcs/fitsfile.c
+++ b/wcs/fitsfile.c
@@ -83,6 +83,7 @@
 #include <sys/file.h>
 #include <errno.h>
 #include <string.h>
+#include <strings.h>
 #include "fitsfile.h"
 
 static int verbose=0;		/* Print diagnostics */

--- a/wcs/imgetwcs.c
+++ b/wcs/imgetwcs.c
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <string.h>
+#include <strings.h>
 
 #include "wcs.h"
 #include "lwcs.h"

--- a/wcs/wcscon.c
+++ b/wcs/wcscon.c
@@ -71,6 +71,7 @@
 #include <stdio.h>	/* for fprintf() and sprintf() */
 #include <ctype.h>
 #include <string.h>
+#include <strings.h>
 #include "wcs.h"
 
 void fk524(), fk524e(), fk524m(), fk524pv();


### PR DESCRIPTION
For plan404:

- avoid redefining functions available in math.h
- define argument types in function definitions

For wcs:

- force `-std=c99 -D_XOPEN_SOURCE=500` to compiler flags
- add `#define _GNU_SOURCE` to dateutils to fix non standard function definition
- add `#include <strings.h>` to fix some string functions not found
